### PR TITLE
fix #374 - fix voucher request reminder process

### DIFF
--- a/plugins/cc-global-network/cron/email-vouch-request-reminders.php
+++ b/plugins/cc-global-network/cron/email-vouch-request-reminders.php
@@ -104,7 +104,7 @@ function ccgn_email_vouch_request_reminders () {
         // which is the last time their Vouchers were initially notified.
         $days_in_state = ccgn_days_since_state_set ( $applicant_id, $now );
         $date_last_set_to_state = get_user_meta(
-            $user_id
+            $applicant_id
         )[ CCGN_APPLICATION_STATE_DATE ][ 0 ];
         $request_date = new DateTime( $date_last_set_to_state );
         # php 5.2.2 or later for DateTime comparisons....

--- a/plugins/cc-global-network/includes/gravityforms-interaction.php
+++ b/plugins/cc-global-network/includes/gravityforms-interaction.php
@@ -593,7 +593,7 @@ function ccgn_vouching_request_spoof_cannot($applicant_id, $voucher_id)
         'SPOOFING "CANNOT" VOUCH ENTRY: this is due to the Voucher not responding in time.'
     );
     // If applicant is vouching, they must now update vouchers
-    ccgn_registration_user_set_stage_update_vouchers($application_id);
+    ccgn_registration_user_set_stage_update_vouchers($applicant_id);
     return true;
 }
 


### PR DESCRIPTION
Fixes #374 

## Description
Fixed a bug that doesn't send the number of days passed since the last user state update, because of that, the reminder emails were never sent.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
