### PR TITLE
Less aggressive notification times

### DIFF
--- a/plugins/cc-global-network/cron/email-vouch-request-reminders.php
+++ b/plugins/cc-global-network/cron/email-vouch-request-reminders.php
@@ -15,10 +15,10 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 // Defines
 ////////////////////////////////////////////////////////////////////////////////
 
-define('CCGN_VOUCH_REQUEST_REMINDER_DAY_FIRST_REMINDER', 1);
-define('CCGN_VOUCH_REQUEST_REMINDER_DAY_SECOND_REMINDER', 3);
-define('CCGN_VOUCH_REQUEST_REMINDER_DAY_FINAL_REMINDER', 5);
-define('CCGN_VOUCH_REQUEST_REMINDER_DAY_CLOSE', 6);
+define('CCGN_VOUCH_REQUEST_REMINDER_DAY_FIRST_REMINDER', 3);
+define('CCGN_VOUCH_REQUEST_REMINDER_DAY_SECOND_REMINDER', 6);
+define('CCGN_VOUCH_REQUEST_REMINDER_DAY_FINAL_REMINDER', 8);
+define('CCGN_VOUCH_REQUEST_REMINDER_DAY_CLOSE', 14);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Checking and sending
@@ -111,7 +111,7 @@ function ccgn_email_vouch_request_reminders () {
         $day = ($now->diff($request_date))->days;
         $vouchers = ccgn_application_vouchers_users_ids ( $applicant_id );
         foreach ( $vouchers as $voucher_id ) {
-            if ( ccgn_vouching_request_open ( $applicant_id, $voucher_id ) && ccgn_registration_user_is_vouchable ( $applicant_id ) ) {
+            if ( ccgn_vouching_request_open ( $applicant_id, $voucher_id ) ) {
                 ccgn_email_vouch_request_reminder_maybe_close (
                     $voucher_id,
                     $applicant_id,

--- a/plugins/cc-global-network/cron/email-vouch-request-reminders.php
+++ b/plugins/cc-global-network/cron/email-vouch-request-reminders.php
@@ -111,18 +111,18 @@ function ccgn_email_vouch_request_reminders () {
         $day = ($now->diff($request_date))->days;
         $vouchers = ccgn_application_vouchers_users_ids ( $applicant_id );
         foreach ( $vouchers as $voucher_id ) {
-            if ( ccgn_vouching_request_open ( $applicant_id, $voucher_id ) ) {
-                 ccgn_email_vouch_request_reminder_maybe_close (
+            if ( ccgn_vouching_request_open ( $applicant_id, $voucher_id ) && ccgn_registration_user_is_vouchable ( $applicant_id ) ) {
+                ccgn_email_vouch_request_reminder_maybe_close (
                     $voucher_id,
                     $applicant_id,
                     $day
                 );
                 // This will notify the voucher if the request was closed
-                 ccgn_email_vouch_request_reminder_send (
+                ccgn_email_vouch_request_reminder_send (
                     $voucher_id,
                     $applicant_id,
                     $day
-                 );
+                );
             }
         }
     }


### PR DESCRIPTION
Fixes #376 

## Description
Notification reminder days seems to be a little bit aggressive. These days were modified in order to extend the period to respond to a vouching request


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
