### PR TITLE
Fix process to manually change vouchers

### DIFF
--- a/plugins/cc-global-network/admin/user-application-page.php
+++ b/plugins/cc-global-network/admin/user-application-page.php
@@ -912,6 +912,8 @@ function ccgn_ajax_change_voucher()
         $update_date = GFAPI::update_entry_field($entry_id, 'date_updated', date('Y-m-d H:m:s'));
         $change_voucher_result = GFAPI::update_entry_field($entry_id, $position, $new_voucher);
         if ($change_voucher_result) {
+            //change user state to "vouching". if we dont't do this, the applicant will not appear to the new voucher request list
+            _ccgn_registration_user_set_stage( $applicant_id, CCGN_APPLICATION_STATE_VOUCHING );
             //send email to the new voucher
             $send_mail = ccgn_registration_email_vouching_request(
                 $applicant_id,

--- a/plugins/cc-global-network/includes/application-state.php
+++ b/plugins/cc-global-network/includes/application-state.php
@@ -179,9 +179,14 @@ function _ccgn_registration_user_set_stage( $user_id, $stage ) {
     );
 }
 
-// Note that this isn't general-purpose: it will refuse to update if the user
-// is past final approval
-
+/**
+ * User set stage
+ * Change user stage but it will refuse this change if the user is past final approval
+ *
+ * @param int $user_id
+ * @param string $stage
+ * @return void
+ */
 function ccgn_registration_user_set_stage ( $user_id, $stage ) {
     $current = ccgn_registration_user_get_stage( $user_id );
     if ( ! in_array( $current, CCGN_APPLICATION_STATE_PAST_APPROVAL ) ) {


### PR DESCRIPTION
Fixes #379

## Description
This fix changes the applicant status to `vouching` when we manually change vouchers, otherwise, the newly selected voucher will not see the applicant request


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
