### PR TITLE
fix update details WordPresscron jobs

### DIFF
--- a/plugins/cc-global-network/cron/email-update-details-reminders.php
+++ b/plugins/cc-global-network/cron/email-update-details-reminders.php
@@ -39,6 +39,28 @@ function ccgn_close_update_details_applicant($applicant_id)
     $delete = wp_delete_user($applicant_id);
 }
 
+function ccgn_update_details_set_first_reminder( $applicant_id ) {
+    ccgn_registration_email_update_details_first_reminder($applicant_id);
+    $update_details_meta = array(
+        'state' => 'first-reminder',
+        'updated' => 0,
+        'date' => date('Y-m-d H:i:s', strtotime('now')),
+        'done' => true
+    );
+    update_user_meta( $applicant_id, 'ccgn_applicant_update_details_state', $update_details_meta );
+}
+
+function ccgn_update_details_set_second_reminder( $applicant_id ) {
+    ccgn_registration_email_update_details_second_reminder($applicant_id);
+    $update_details_meta = array(
+        'state' => 'second-reminder',
+        'updated' => 0,
+        'date' => date('Y-m-d H:i:s', strtotime('now')),
+        'done' => true
+    );
+    update_user_meta($applicant_id, 'ccgn_applicant_update_details_state', $update_details_meta);
+}
+
 // Send reminders to those that need them
 
 function ccgn_email_update_details_reminders()
@@ -49,10 +71,16 @@ function ccgn_email_update_details_reminders()
     );
     foreach ($applicants as $applicant_id) {
         $status = get_user_meta($applicant_id, 'ccgn_applicant_update_details_state', true);
-        $days_in_state = ccgn_days_since_state_set($applicant_id, $now);
+        $state_date = new DateTime($status['date']);
+        $days_in_state = $state_date->diff($now)->days;
         if ($days_in_state > CCGN_CLOSE_UPDATE_DETAILS_AFTER_DAYS) {
             if ( ($status['state'] == 'second-reminder') && ($status['done']) ) {
                 ccgn_close_update_details_applicant($applicant_id);
+            } elseif ( $status['state'] == 'none' ) {
+                ccgn_update_details_set_first_reminder($applicant_id);
+            } elseif ( $status['state'] == 'first-reminder' ) {
+                echo "HEY I'M STUCK ON FIRST REMINDER \n";
+                ccgn_update_details_set_second_reminder($applicant_id);
             } else {
                 //update user status date
                 update_user_meta(
@@ -64,26 +92,12 @@ function ccgn_email_update_details_reminders()
         } elseif ( ($days_in_state > CCGN_FIRST_REMINDER_UPDATE_DETAILS_AFTER_DAYS) && ($days_in_state <= CCGN_SECOND_REMINDER_UPDATE_DETAILS_AFTER_DAYS) ) {
             // Send first reminder
             if (empty($status['state'])) {
-                ccgn_registration_email_update_details_first_reminder($applicant_id);
-                $update_details_meta = array(
-                    'state' => 'first-reminder',
-                    'updated' => 0,
-                    'date' => date('Y-m-d H:i:s', strtotime('now')),
-                    'done' => true
-                );
-                update_user_meta( $applicant_id, 'ccgn_applicant_update_details_state', $update_details_meta );
+                ccgn_update_details_set_first_reminder($applicant_id);
             }
         } elseif ( ($days_in_state > CCGN_SECOND_REMINDER_UPDATE_DETAILS_AFTER_DAYS) && ($days_in_state <= CCGN_CLOSE_UPDATE_DETAILS_AFTER_DAYS) ) {
             // Send second reminder
             if (($status['state'] == 'first-reminer') && ($status['done'])) {
-                ccgn_registration_email_update_details_second_reminder($applicant_id);
-                $update_details_meta = array(
-                    'state' => 'second-reminder',
-                    'updated' => 0,
-                    'date' => date('Y-m-d H:i:s', strtotime('now')),
-                    'done' => true
-                );
-                update_user_meta($applicant_id, 'ccgn_applicant_update_details_state', $update_details_meta);
+                ccgn_update_details_set_second_reminder($applicant_id);
             }
         }
     }

--- a/plugins/cc-global-network/cron/email-update-details-reminders.php
+++ b/plugins/cc-global-network/cron/email-update-details-reminders.php
@@ -79,7 +79,6 @@ function ccgn_email_update_details_reminders()
             } elseif ( $status['state'] == 'none' ) {
                 ccgn_update_details_set_first_reminder($applicant_id);
             } elseif ( $status['state'] == 'first-reminder' ) {
-                echo "HEY I'M STUCK ON FIRST REMINDER \n";
                 ccgn_update_details_set_second_reminder($applicant_id);
             } else {
                 //update user status date


### PR DESCRIPTION
## Fixes
Fixes #382 by @claudioruiz 

## Description
The script got stuck in a no-return point because it wasn't reading the correct date to compare the days. Everything is now fixed and:
- Users stuck with no reminder will have their first-reminder
- Users stuck with first reminders will now have their second reminder

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
