### PR TITLE
fix all members query in admin section

### DIFF
--- a/plugins/cc-global-network/admin/list-members.php
+++ b/plugins/cc-global-network/admin/list-members.php
@@ -354,7 +354,7 @@ function ccgn_rest_return_members()
     $return_data = array();
     if (rest_cookie_check_errors() && $the_user->has_cap('ccgn_list_applications')) {
         $default =  array(
-			'subscriber' => 'subscriber',
+            'subscriber' => 'subscriber',
             'orderby' => 'date',
             'order' => 'DESC',
             'meta_query' => array(
@@ -363,10 +363,9 @@ function ccgn_rest_return_members()
                     'value' => 'accepted'
                 )
             )
-		);
+        );
         $query = new WP_User_Query($default);
         $individuals = $query->get_results();
-        //$individuals = ccgn_new_final_approvals_since($start_date, $end_date);
         $final_approval_form_id = RGFormsModel::get_form_id(CCGN_GF_FINAL_APPROVAL);
         foreach ($individuals as $member) {
             $user = $member;
@@ -382,7 +381,6 @@ function ccgn_rest_return_members()
             $approval_entry = GFAPI::get_entries( $final_approval_form_id, $search_criteria );
             $approval_date = (!empty($approval_entry[0]['date_created'])) ? $approval_entry[0]['date_created'] : CCGN_SITE_EPOCH ;
             $user_data = array();
-            $member_last_date = get_user_meta( $member_id, CCGN_APPLICATION_STATE_DATE, true);
             $user_data['user_id'] = $member_id;
             $user_data['user_type'] = ccgn_applicant_type_desc($member_id);
             $user_data['user_url'] = ccgn_application_user_application_page_url($user->data->ID);

--- a/plugins/cc-global-network/includes/gravityforms-interaction.php
+++ b/plugins/cc-global-network/includes/gravityforms-interaction.php
@@ -401,7 +401,7 @@ define('CCGN_CLEANUP_DAYS', 21);
 
 function ccgn_gf_get_paged_all($form_id, $search_criteria, $sorting)
 {
-    $page_size = 100;
+    $page_size = 200;
     $results = array();
     $paging = array('offset' => 0, 'page_size' => $page_size);
     while (true) {


### PR DESCRIPTION
## Fixes
Fixes creativecommons/tech-support#647 by @Juliabrungs 

## Description
This PR fixes the query for all users in the admin section. this happened because the prior query compare the users in the "*Final Approval*" form and there were some users that don't appear on that form because at the beginning of times the site didn't have that approval workflow.
I replace those users approval dates with the beginning date of the website (2017-10-15)

## Technical details
I replace the query to the *final approval* form with the `WP_User_Query` WordPress class so we ensure all users are included now.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
