### PR TITLE
add redirection to homepage for non-users profile page

### DIFF
--- a/themes/cc-commoners-2019/inc/bp-integration.php
+++ b/themes/cc-commoners-2019/inc/bp-integration.php
@@ -9,6 +9,13 @@ class bp_commoners {
             return false;
         }
     }
+    static function check_if_user_is_accepted() {
+        $active = ccgn_registration_user_get_stage_and_date( bp_displayed_user_id() );
+        if ( active['stage'] != 'accepted' ) {
+            wp_redirect( home_url() );
+            exit;
+        }
+    }
     static function add_user_meta($text) {
         $user_id = bp_displayed_user_id();
         $displayed_user = get_user_by('ID', $user_id );
@@ -22,4 +29,5 @@ class bp_commoners {
         }
     }
 }
+add_action('bp_members_screen_display_profile', array( 'bp_commoners', 'check_if_user_is_accepted' ), 10, 1);
 add_action('bp_profile_header_meta', array( 'bp_commoners', 'add_user_meta' ),10,1);


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/tech-support/issues/675 by @Juliabrungs (private repo)

## Description
This PR adds a redirection in case the applicant hasn't been approved yet, we don't need to show their profile page

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
